### PR TITLE
Add Shared type to fix inference fail on nightly

### DIFF
--- a/src/conslist.rs
+++ b/src/conslist.rs
@@ -26,6 +26,7 @@ use std::ops::Deref;
 use std::hash::{Hash, Hasher};
 use std::cmp::Ordering;
 use std::borrow::Borrow;
+use shared::Shared;
 
 use self::ConsListNode::{Cons, Nil};
 
@@ -113,7 +114,7 @@ macro_rules! conslist {
 /// untrained ear.
 pub fn cons<A, RA, RD>(car: RA, cdr: RD) -> ConsList<A>
 where
-    Arc<A>: From<RA>,
+    RA: Shared<A>,
     RD: Borrow<ConsList<A>>,
 {
     cdr.borrow().cons(car)
@@ -149,9 +150,9 @@ impl<A> ConsList<A> {
     /// Construct a list with a single element.
     pub fn singleton<R>(v: R) -> ConsList<A>
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
-        ConsList(Arc::new(Cons(1, Arc::from(v), conslist![])))
+        ConsList(Arc::new(Cons(1, v.shared(), conslist![])))
     }
 
     /// Construct a list by consuming an `IntoIterator`.
@@ -176,9 +177,9 @@ impl<A> ConsList<A> {
     pub fn from<R, I>(it: I) -> ConsList<A>
     where
         I: IntoIterator<Item = R>,
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
-        it.into_iter().map(|a| Arc::from(a)).collect()
+        it.into_iter().map(|a| a.shared()).collect()
     }
 
     /// Test whether a list is empty.
@@ -197,9 +198,9 @@ impl<A> ConsList<A> {
     /// Time: O(1)
     pub fn cons<R>(&self, car: R) -> ConsList<A>
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
-        ConsList(Arc::new(Cons(self.len() + 1, Arc::from(car), self.clone())))
+        ConsList(Arc::new(Cons(self.len() + 1, car.shared(), self.clone())))
     }
 
     /// Get the first element of a list.
@@ -491,9 +492,9 @@ where
     /// ```
     pub fn insert<T>(&self, item: T) -> ConsList<A>
     where
-        Arc<A>: From<T>,
+        T: Shared<A>,
     {
-        self.insert_ref(Arc::from(item))
+        self.insert_ref(item.shared())
     }
 
     fn insert_ref(&self, item: Arc<A>) -> ConsList<A> {
@@ -709,7 +710,7 @@ impl<A> Sum for ConsList<A> {
 
 impl<A, T> FromIterator<T> for ConsList<A>
 where
-    Arc<A>: From<T>,
+    T: Shared<A>,
 {
     fn from_iter<I>(source: I) -> Self
     where
@@ -726,28 +727,28 @@ where
 
 impl<'a, A, R> From<&'a [R]> for ConsList<A>
 where
-    Arc<A>: From<&'a R>,
+    &'a R: Shared<A>,
 {
     fn from(slice: &'a [R]) -> Self {
-        slice.into_iter().map(|a| Arc::from(a)).collect()
+        slice.into_iter().map(|a| a.shared()).collect()
     }
 }
 
 impl<A, R> From<Vec<R>> for ConsList<A>
 where
-    Arc<A>: From<R>,
+    R: Shared<A>,
 {
     fn from(vec: Vec<R>) -> Self {
-        vec.into_iter().map(|a| Arc::from(a)).collect()
+        vec.into_iter().map(|a| a.shared()).collect()
     }
 }
 
 impl<'a, A, R> From<&'a Vec<R>> for ConsList<A>
 where
-    Arc<A>: From<&'a R>,
+    &'a R: Shared<A>,
 {
     fn from(vec: &'a Vec<R>) -> Self {
-        vec.into_iter().map(|a| Arc::from(a)).collect()
+        vec.into_iter().map(|a| a.shared()).collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub mod list;
 pub mod queue;
 pub mod iter;
 pub mod lens;
+pub mod shared;
 
 pub use conslist::ConsList;
 pub use map::Map;

--- a/src/list.rs
+++ b/src/list.rs
@@ -20,6 +20,7 @@ use std::hash::{Hash, Hasher};
 use std::fmt::{Debug, Formatter, Error};
 use std::borrow::Borrow;
 use queue::Queue;
+use shared::Shared;
 
 use self::ListNode::{Nil, Cons};
 
@@ -104,7 +105,7 @@ macro_rules! list {
 /// untrained ear.
 pub fn cons<A, RA, RD>(car: RA, cdr: RD) -> List<A>
 where
-    Arc<A>: From<RA>,
+    RA: Shared<A>,
     RD: Borrow<List<A>>,
 {
     cdr.borrow().cons(car)
@@ -138,7 +139,7 @@ impl<A> List<A> {
     /// Construct a list with a single value.
     pub fn singleton<R>(a: R) -> Self
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
         List::new().push_front(a)
     }
@@ -165,9 +166,9 @@ impl<A> List<A> {
     pub fn from<R, I>(it: I) -> List<A>
     where
         I: IntoIterator<Item = R>,
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
-        it.into_iter().map(|a| Arc::from(a)).collect()
+        it.into_iter().map(|a| a.shared()).collect()
     }
 
     /// Test whether a list is empty.
@@ -269,16 +270,16 @@ impl<A> List<A> {
     /// current list.
     pub fn cons<R>(&self, a: R) -> Self
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
-        List(Arc::new(Cons(1, Arc::from(a), Queue::new()))).append(self)
+        List(Arc::new(Cons(1, a.shared(), Queue::new()))).append(self)
     }
 
     /// Construct a list with a new value prepended to the front of the
     /// current list.
     pub fn push_front<R>(&self, a: R) -> Self
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
         self.cons(a)
     }
@@ -292,16 +293,16 @@ impl<A> List<A> {
     /// doubt did, this method is also available as `List::push_back()`.
     pub fn snoc<R>(&self, a: R) -> Self
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
-        self.append(&List(Arc::new(Cons(1, Arc::from(a), Queue::new()))))
+        self.append(&List(Arc::new(Cons(1, a.shared(), Queue::new()))))
     }
 
     /// Construct a list with a new value appended to the back of the
     /// current list.
     pub fn push_back<R>(&self, a: R) -> Self
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
         self.snoc(a)
     }
@@ -522,9 +523,9 @@ impl<A: Ord> List<A> {
     /// ```
     pub fn insert<T>(&self, item: T) -> Self
     where
-        Arc<A>: From<T>,
+        T: Shared<A>,
     {
-        self.insert_ref(Arc::from(item))
+        self.insert_ref(item.shared())
     }
 
     fn insert_ref(&self, item: Arc<A>) -> Self {
@@ -698,7 +699,7 @@ impl<A> Sum for List<A> {
 
 impl<A, T> FromIterator<T> for List<A>
 where
-    Arc<A>: From<T>,
+    T: Shared<A>,
 {
     fn from_iter<I>(source: I) -> Self
     where
@@ -712,7 +713,7 @@ where
 
 impl<'a, A, T> From<&'a [T]> for List<A>
 where
-    Arc<A>: From<&'a T>,
+    &'a T: Shared<A>,
 {
     fn from(slice: &'a [T]) -> List<A> {
         slice.into_iter().collect()
@@ -721,7 +722,7 @@ where
 
 impl<A, T> From<Vec<T>> for List<A>
 where
-    Arc<A>: From<T>,
+    T: Shared<A>,
 {
     fn from(vec: Vec<T>) -> List<A> {
         vec.into_iter().collect()
@@ -730,7 +731,7 @@ where
 
 impl<'a, A, T> From<&'a Vec<T>> for List<A>
 where
-    Arc<A>: From<&'a T>,
+    &'a T: Shared<A>,
 {
     fn from(vec: &'a Vec<T>) -> List<A> {
         vec.into_iter().collect()

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::iter::FromIterator;
 use std::fmt;
 use conslist::ConsList;
+use shared::Shared;
 
 /// A strict queue backed by a pair of linked lists.
 ///
@@ -26,9 +27,9 @@ impl<A> Queue<A> {
     pub fn from<R, I>(it: I) -> Queue<A>
     where
         I: IntoIterator<Item = R>,
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
-        it.into_iter().map(|a| Arc::from(a)).collect()
+        it.into_iter().map(|a| a.shared()).collect()
     }
 
     /// Test whether a queue is empty.
@@ -51,7 +52,7 @@ impl<A> Queue<A> {
     /// Time: O(1)
     pub fn push<R>(&self, v: R) -> Self
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
         Queue(self.0.clone(), self.1.cons(v))
     }
@@ -142,7 +143,7 @@ impl<'a, A> IntoIterator for &'a Queue<A> {
 
 impl<A, T> FromIterator<T> for Queue<A>
 where
-    Arc<A>: From<T>,
+    T: Shared<A>,
 {
     fn from_iter<I>(source: I) -> Self
     where
@@ -156,7 +157,7 @@ where
 
 impl<'a, A, T> From<&'a [T]> for Queue<A>
 where
-    Arc<A>: From<&'a T>,
+    &'a T: Shared<A>,
 {
     fn from(slice: &'a [T]) -> Queue<A> {
         slice.into_iter().collect()
@@ -165,7 +166,7 @@ where
 
 impl<A, T> From<Vec<T>> for Queue<A>
 where
-    Arc<A>: From<T>,
+    T: Shared<A>,
 {
     fn from(vec: Vec<T>) -> Queue<A> {
         vec.into_iter().collect()
@@ -174,7 +175,7 @@ where
 
 impl<'a, A, T> From<&'a Vec<T>> for Queue<A>
 where
-    Arc<A>: From<&'a T>,
+    &'a T: Shared<A>,
 {
     fn from(vec: &'a Vec<T>) -> Queue<A> {
         vec.into_iter().collect()

--- a/src/set.rs
+++ b/src/set.rs
@@ -14,6 +14,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Add, Mul};
 use std::borrow::Borrow;
 use map::{self, Map};
+use shared::Shared;
 
 /// Construct a set from a sequence of values.
 ///
@@ -71,7 +72,7 @@ impl<A> Set<A> {
     /// ```
     pub fn singleton<R>(a: R) -> Self
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
         Set(Map::<A, ()>::singleton(a, ()))
     }
@@ -155,7 +156,7 @@ impl<A: Ord> Set<A> {
     /// ```
     pub fn insert<R>(&self, a: R) -> Self
     where
-        Arc<A>: From<R>,
+        R: Shared<A>,
     {
         Set(self.0.insert(a, ()))
     }
@@ -369,7 +370,7 @@ impl<A> Iterator for Iter<A> {
 
 impl<A: Ord, RA> FromIterator<RA> for Set<A>
 where
-    Arc<A>: From<RA>,
+    RA: Shared<A>,
 {
     fn from_iter<T>(i: T) -> Self
     where

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,0 +1,20 @@
+// This module works around the fact that you can't rely on 
+// `Arc<T>: From<U>` to only have one possible implementation anymore (that is, where `U = T`).
+
+use std::sync::Arc;
+
+pub trait Shared<T> {
+    fn shared(self) -> Arc<T>;
+}
+
+impl<T> Shared<T> for T {
+    fn shared(self) -> Arc<T> {
+        Arc::from(self)
+    }
+}
+
+impl<T> Shared<T> for Arc<T> {
+    fn shared(self) -> Arc<T> {
+        self
+    }
+}


### PR DESCRIPTION
Hi there!

In https://github.com/rust-lang/rust/pull/42565 some new impls were added to `Arc` and friends that are breaking type inference on this crate for string keys/values. This was originally reported [here](https://github.com/rust-lang/rust/issues/44446).

The trait bounds here worked previously because we only had `impl<T> From<T> for Arc<T>` in the standard library, so in the bound `Arc<T>: From<U>`, `U` could only ever be `T`. That's not the case anymore, so Rust can't figure out what `T` should be from `U`. I'm assuming the reason for these bounds here was so that you could pass either `T` or `Arc<T>` to some of the datastructures and have it do the right thing.

To work around this I've added a trait that's implemented only for `T` and `Arc<T>`, so when we get a generic `T: Shared<U>` we know that `T` must be either `U` or `Arc<U>`. I haven't tried to come up with a good name for this trait or add any docs, in case this isn't the way you want to solve this problem.

This is technically a breaking change. An alternative solution is that callers will just need to give Rust a hand and specify the type of maps and things when it can't figure it out itself.

cc: @bodil 