### PR TITLE
Use debug formatting helpers

### DIFF
--- a/src/catlist.rs
+++ b/src/catlist.rs
@@ -915,28 +915,7 @@ impl<A: Hash> Hash for CatList<A> {
 
 impl<A: Debug> Debug for CatList<A> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        // write!(
-        //     f,
-        //     "[ Len {} Head {}:{:?} Tail {:?} ]",
-        //     self.0.size,
-        //     self.0.head.len(),
-        //     self.0.head,
-        //     self.0.tail
-        // )
-        write!(f, "[")?;
-        let mut it = self.iter().peekable();
-        loop {
-            match it.next() {
-                None => break,
-                Some(a) => {
-                    write!(f, "{:?}", a)?;
-                    if it.peek().is_some() {
-                        write!(f, ", ")?;
-                    }
-                }
-            }
-        }
-        write!(f, "]")
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 

--- a/src/conslist.rs
+++ b/src/conslist.rs
@@ -356,9 +356,7 @@ impl<A> ConsList<A> {
             cmp: &Fn(&A, &A) -> Ordering,
         ) -> ConsList<A> {
             match (la.uncons(), lb.uncons()) {
-                (Some((ref a, _)), Some((ref b, ref lb1)))
-                    if cmp(a, b) == Ordering::Greater =>
-                {
+                (Some((ref a, _)), Some((ref b, ref lb1))) if cmp(a, b) == Ordering::Greater => {
                     cons(b.clone(), &merge(la, lb1, cmp))
                 }
                 (Some((a, la1)), Some((_, _))) => cons(a.clone(), &merge(&la1, lb, cmp)),
@@ -377,10 +375,7 @@ impl<A> ConsList<A> {
             }
         }
 
-        fn merge_all<A>(
-            l: &ConsList<ConsList<A>>,
-            cmp: &Fn(&A, &A) -> Ordering,
-        ) -> ConsList<A> {
+        fn merge_all<A>(l: &ConsList<ConsList<A>>, cmp: &Fn(&A, &A) -> Ordering) -> ConsList<A> {
             match l.uncons() {
                 None => conslist![],
                 Some((ref a, ref d)) if d.is_empty() => a.deref().clone(),
@@ -416,10 +411,7 @@ impl<A> ConsList<A> {
             }
         }
 
-        fn sequences<A>(
-            l: &ConsList<A>,
-            cmp: &Fn(&A, &A) -> Ordering,
-        ) -> ConsList<ConsList<A>> {
+        fn sequences<A>(l: &ConsList<A>, cmp: &Fn(&A, &A) -> Ordering) -> ConsList<ConsList<A>> {
             match l.uncons2() {
                 Some((ref a, ref b, ref xs)) if cmp(a, b) == Ordering::Greater => {
                     descending(&b.clone(), &ConsList::singleton(a.clone()), xs, cmp)
@@ -634,32 +626,9 @@ impl<A> Add for ConsList<A> {
     }
 }
 
-impl<A> Debug for ConsList<A>
-where
-    A: Debug,
-{
+impl<A: Debug> Debug for ConsList<A> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        fn items<A>(l: &ConsList<A>, f: &mut Formatter) -> Result<(), Error>
-        where
-            A: Debug,
-        {
-            match *l.0 {
-                Nil => Ok(()),
-                Cons(_, ref a, ref d) => {
-                    write!(f, ", {:?}", a)?;
-                    items(d, f)
-                }
-            }
-        }
-        write!(f, "[")?;
-        match *self.0 {
-            Nil => Ok(()),
-            Cons(_, ref a, ref d) => {
-                write!(f, "{:?}", a)?;
-                items(d, f)
-            }
-        }?;
-        write!(f, "]")
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -1240,21 +1240,7 @@ where
     S: BuildHasher,
 {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{{ ")?;
-        let mut it = self.iter().peekable();
-        loop {
-            match it.next() {
-                None => break,
-                Some((k, v)) => {
-                    write!(f, "{:?} => {:?}", k, v)?;
-                    match it.peek() {
-                        None => write!(f, " ")?,
-                        Some(_) => write!(f, ", ")?,
-                    }
-                }
-            }
-        }
-        write!(f, "}}")
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 
@@ -1266,21 +1252,7 @@ where
     S: BuildHasher,
 {
     default fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{{ ")?;
-        let mut it = self.iter().peekable();
-        loop {
-            match it.next() {
-                None => break,
-                Some((k, v)) => {
-                    write!(f, "{:?} => {:?}", k, v)?;
-                    match it.peek() {
-                        None => write!(f, " ")?,
-                        Some(_) => write!(f, ", ")?,
-                    }
-                }
-            }
-        }
-        write!(f, "}}")
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 
@@ -1292,23 +1264,7 @@ where
     S: BuildHasher,
 {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        let mut keys: Vec<_> = self.keys().collect();
-        keys.sort();
-        write!(f, "{{ ")?;
-        let mut it = keys.iter().peekable();
-        loop {
-            match it.next() {
-                None => break,
-                Some(k) => {
-                    write!(f, "{:?} => {:?}", k, self[k])?;
-                    match it.peek() {
-                        None => write!(f, " ")?,
-                        Some(_) => write!(f, ", ")?,
-                    }
-                }
-            }
-        }
-        write!(f, "}}")
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 
@@ -1600,9 +1556,9 @@ mod test {
     #[test]
     fn proper_formatting() {
         let map = hashmap![1 => 2];
-        assert_eq!("{ 1 => 2 }", format!("{:?}", map));
+        assert_eq!("{1: 2}", format!("{:?}", map));
 
-        assert_eq!("{ }", format!("{:?}", HashMap::<(), ()>::new()));
+        assert_eq!("{}", format!("{:?}", HashMap::<(), ()>::new()));
     }
 
     #[test]

--- a/src/hashset.rs
+++ b/src/hashset.rs
@@ -518,65 +518,21 @@ where
 #[cfg(not(has_specialisation))]
 impl<A: Hash + Eq + Debug, S: BuildHasher + Default> Debug for HashSet<A, S> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{{ ")?;
-        let mut it = self.iter().peekable();
-        loop {
-            match it.next() {
-                None => break,
-                Some(a) => {
-                    write!(f, "{:?}", a)?;
-                    match it.peek() {
-                        None => write!(f, " ")?,
-                        Some(_) => write!(f, ", ")?,
-                    }
-                }
-            }
-        }
-        write!(f, "}}")
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 
 #[cfg(has_specialisation)]
 impl<A: Hash + Eq + Debug, S: BuildHasher + Default> Debug for HashSet<A, S> {
     default fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{{ ")?;
-        let mut it = self.iter().peekable();
-        loop {
-            match it.next() {
-                None => break,
-                Some(a) => {
-                    write!(f, "{:?}", a)?;
-                    match it.peek() {
-                        None => write!(f, " ")?,
-                        Some(_) => write!(f, ", ")?,
-                    }
-                }
-            }
-        }
-        write!(f, "}}")
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 
 #[cfg(has_specialisation)]
 impl<A: Hash + Eq + Debug + Ord, S: BuildHasher + Default> Debug for HashSet<A, S> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        let mut keys: Vec<_> = self.iter().collect();
-        keys.sort();
-        write!(f, "{{ ")?;
-        let mut it = keys.iter().peekable();
-        loop {
-            match it.next() {
-                None => break,
-                Some(a) => {
-                    write!(f, "{:?}", a)?;
-                    match it.peek() {
-                        None => write!(f, " ")?,
-                        Some(_) => write!(f, ", ")?,
-                    }
-                }
-            }
-        }
-        write!(f, "}}")
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 

--- a/src/nodes/vector.rs
+++ b/src/nodes/vector.rs
@@ -42,8 +42,8 @@ impl<A> Clone for Entry<A> {
 impl<A: Debug> Debug for Entry<A> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match *self {
-            Entry::Node(ref node) => write!(f, "Node{:?}", node),
-            Entry::Value(ref value) => write!(f, "Value[ {:?} ]", value),
+            Entry::Node(ref node) => f.debug_tuple("Node").field(node).finish(),
+            Entry::Value(ref value) => f.debug_tuple("Value").field(value).finish(),
             Entry::Empty => write!(f, "Empty"),
         }
     }

--- a/src/ordmap.rs
+++ b/src/ordmap.rs
@@ -1193,21 +1193,7 @@ where
     K: Ord,
 {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{{ ")?;
-        let mut it = self.iter().peekable();
-        loop {
-            match it.next() {
-                None => break,
-                Some((k, v)) => {
-                    write!(f, "{:?} => {:?}", k, v)?;
-                    match it.peek() {
-                        None => write!(f, " ")?,
-                        Some(_) => write!(f, ", ")?,
-                    }
-                }
-            }
-        }
-        write!(f, "}}")
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 
@@ -1584,7 +1570,7 @@ mod test {
     fn debug_output() {
         assert_eq!(
             format!("{:?}", ordmap!{ 3 => 4, 5 => 6, 1 => 2 }),
-            "{ 1 => 2, 3 => 4, 5 => 6 }"
+            "{1: 2, 3: 4, 5: 6}"
         );
     }
 

--- a/src/ordset.rs
+++ b/src/ordset.rs
@@ -542,21 +542,7 @@ where
 
 impl<A: Ord + Debug> Debug for OrdSet<A> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{{ ")?;
-        let mut it = self.iter().peekable();
-        loop {
-            match it.next() {
-                None => break,
-                Some(a) => {
-                    write!(f, "{:?}", a)?;
-                    match it.peek() {
-                        None => write!(f, " ")?,
-                        Some(_) => write!(f, ", ")?,
-                    }
-                }
-            }
-        }
-        write!(f, "}}")
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1059,15 +1059,7 @@ impl<A> Default for Vector<A> {
 
 impl<A: Debug> Debug for Vector<A> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "[")?;
-        let mut it = self.iter().peekable();
-        while let Some(item) = it.next() {
-            write!(f, "{:?}", item)?;
-            if it.peek().is_some() {
-                write!(f, ", ")?;
-            }
-        }
-        write!(f, "]")
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 


### PR DESCRIPTION
This makes the formatting of im’s debug output consistent with Rust’s data structures. These methods also automatically support pretty formatting with `{:#?}`. The downside is that the output no longer mirrors the macro literals, in the case of maps.