### PR TITLE
optimize PartialEq implementations for OrdMap and OrdSet

### DIFF
--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -1126,7 +1126,7 @@ impl<A> DiffIter<A> {
     }
 }
 
-impl<A: Eq> Iterator for DiffIter<A>
+impl<A: PartialEq> Iterator for DiffIter<A>
 where
     A: BTreeValue,
 {

--- a/src/ordmap.rs
+++ b/src/ordmap.rs
@@ -1072,7 +1072,7 @@ impl<K, V> Clone for OrdMap<K, V> {
 #[cfg(not(has_specialisation))]
 impl<K: Ord + PartialEq, V: PartialEq> PartialEq for OrdMap<K, V> {
     fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.iter().eq(other.iter())
+        self.len() == other.len() && self.diff(other).next().is_none()
     }
 }
 
@@ -1082,7 +1082,7 @@ where
     K: Ord,
 {
     default fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.iter().eq(other.iter())
+        self.len() == other.len() && self.diff(other).next().is_none()
     }
 }
 
@@ -1092,7 +1092,8 @@ where
     K: Ord,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.root.ptr_eq(&other.root) || (self.len() == other.len() && self.iter().eq(other.iter()))
+        self.root.ptr_eq(&other.root)
+            || (self.len() == other.len() && self.diff(other).next().is_none())
     }
 }
 

--- a/src/ordset.rs
+++ b/src/ordset.rs
@@ -464,7 +464,8 @@ impl<A> Clone for OrdSet<A> {
 
 impl<A: Ord> PartialEq for OrdSet<A> {
     fn eq(&self, other: &Self) -> bool {
-        self.root.ptr_eq(&other.root) || (self.len() == other.len() && self.iter().eq(other.iter()))
+        self.root.ptr_eq(&other.root)
+            || (self.len() == other.len() && self.diff(other).next().is_none())
     }
 }
 


### PR DESCRIPTION
This replaces `self.iter().eq(other.iter())` with
`self.diff(other).next().is_none()` since the latter knows how to skip
shared nodes, which makes the comparison much faster for sets that
share a lot of structure.