### PR TITLE
make nodes::btree::{DiffItem, DiffIter, Iter} public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,10 @@ pub mod shared;
 #[cfg(any(test, feature = "serde"))]
 pub mod ser;
 
+pub mod btree {
+    pub use nodes::btree::{DiffItem, DiffIter, Iter};
+}
+
 pub use catlist::CatList;
 pub use conslist::ConsList;
 pub use hashmap::HashMap;


### PR DESCRIPTION
This makes the new `diff` functions in `OrdMap` and `OrdSet` useable
outside the `im` crate.  At minimum, `DiffItem` needs to be public in
order for user code to actually do anything with the result of a call
to `diff`.  In addition, it's helpful to make `DiffIter` and `Iter`
public since they're the types returned by the public `diff` and
`iter` functions, and user code may need to refer to them explicitly,
e.g. in return type declarations.