### PR TITLE
Fixes bug in len of ConsList::insert-created list.

### DIFF
--- a/src/conslist.rs
+++ b/src/conslist.rs
@@ -462,7 +462,7 @@ impl<A> ConsList<A> {
         A: Ord,
     {
         match *self.0 {
-            Nil => ConsList(Arc::new(Cons(0, item, ConsList::new()))),
+            Nil => ConsList(Arc::new(Cons(1, item, ConsList::new()))),
             Cons(_, ref a, ref d) => {
                 if a.deref() > item.deref() {
                     self.cons(item)

--- a/src/conslist.rs
+++ b/src/conslist.rs
@@ -798,6 +798,13 @@ mod test {
         assert_eq!(l1, l2);
     }
 
+    #[test]
+    fn len_of_insert_into_empty() {
+        let l1 = ConsList::<i32>::new();
+        let l2 = l1.insert(5);
+        assert_eq!(l2.len(), 1);
+    }
+
     quickcheck! {
         fn length(vec: Vec<i32>) -> bool {
             let list = ConsList::from(vec.clone());


### PR DESCRIPTION
This is a simple bug fix, along with a test. When called on an empty ConsList, insert was creating a node with len of 0 rather than 1, which produced an invalid ConsList.