### PR TITLE
Linear time sum

### DIFF
--- a/benches/conslist.rs
+++ b/benches/conslist.rs
@@ -42,3 +42,11 @@ fn conslist_append(b: &mut Bencher) {
         }
     })
 }
+
+#[bench]
+fn conslist_concat_using_sum(b: &mut Bencher) {
+    let list = ConsList::from_iter(0u32 .. 100);
+    let vec  = vec![list; 100];
+
+    b.iter::<ConsList<u32>, _>(|| vec.iter().map(ConsList::clone).sum())
+}

--- a/src/conslist.rs
+++ b/src/conslist.rs
@@ -346,11 +346,32 @@ impl<A> ConsList<A> {
     /// # }
     /// ```
     pub fn reverse(&self) -> ConsList<A> {
-        let mut out = ConsList::new();
-        for i in self.iter() {
-            out = out.cons(i);
-        }
-        out
+        self.rev_append(ConsList::new())
+    }
+
+    /// Append this list in reverse onto the front of list `right`.
+    ///
+    /// Unlike [`append`](#method.append), this method runs in constant stack space, meaning it
+    /// is safe to use on any length of list. If you want to append two lists in constant stack
+    /// space, you can accomplish this by reversing the first list, and then applying this method.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # #[macro_use] extern crate im;
+    /// # use im::conslist::ConsList;
+    /// # fn main() {
+    /// assert_eq!(
+    ///   conslist![3, 2, 1].rev_append(conslist![7, 8, 9]),
+    ///   conslist![1, 2, 3, 7, 8, 9]
+    /// );
+    /// # }
+    /// ```
+    pub fn rev_append<R>(&self, right: R) -> Self
+    where
+        R: Borrow<Self>
+    {
+        self.iter().fold(right.borrow().clone(), |acc, each| cons(each, acc))
     }
 
     /// Get an iterator over a list.
@@ -695,7 +716,7 @@ impl<A> Sum for ConsList<A> {
     where
         I: Iterator<Item = Self>,
     {
-        it.fold(Self::new(), |a, b| a.append(b))
+        it.fold(Self::new(), |acc, each| each.rev_append(acc)).reverse()
     }
 }
 

--- a/src/conslist.rs
+++ b/src/conslist.rs
@@ -826,6 +826,12 @@ mod test {
         assert_eq!(l2.len(), 1);
     }
 
+    #[test]
+    fn sum_of_vector_of_lists() {
+        assert_eq!(conslist![1, 2, 3, 4, 5, 6, 7, 8],
+                   vec![conslist![1, 2, 3], conslist![4, 5], conslist![6, 7, 8]].into_iter().sum());
+    }
+
     quickcheck! {
         fn length(vec: Vec<i32>) -> bool {
             let list = ConsList::from(vec.clone());


### PR DESCRIPTION
The `impl Sum for ConsList<T>` was quadratic time. This PR makes it linear time. The trick is to build up the whole list in reverse, and then reverse once more at the end. To facilitate this, I added a `rev_append` method that reverses `self` onto the other list. I made it public because I think it's useful, but you could make it private, and then this PR would not change the public API in any way.

It does speed things up, though. Benchmark is concatenating 100 lists of length 100 using `Iterator::sum()`. Before:

```
    test conslist_concat_using_sum ... bench:  99,750,958 ns/iter (+/- 5,266,350)
```

After

```
    test conslist_concat_using_sum ... bench:   4,562,445 ns/iter (+/- 365,896)
```