### PR TITLE
rename public `btree` module to `ord` and add brief documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,8 @@ pub mod shared;
 #[cfg(any(test, feature = "serde"))]
 pub mod ser;
 
-pub mod btree {
+/// Types shared between `OrdMap` and `OrdSet`.
+pub mod ord {
     pub use nodes::btree::{DiffItem, DiffIter, Iter};
 }
 


### PR DESCRIPTION
The name `ord` seems more appropriate given the naming conventions in
the rest of the public API.

This also adds a bit of documentation so `ord` doesn't stick out as
the only module with no description in the generated docs.