### PR TITLE
Allow trailing commas in macros

### DIFF
--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -70,6 +70,14 @@ macro_rules! hashmap {
         })*;
         map
     }};
+
+    ( $( $key:expr => $value:expr ,)* ) => {{
+        let mut map = $crate::hashmap::HashMap::new();
+        $({
+            map.insert_mut($key, $value);
+        })*;
+        map
+    }};
 }
 
 /// A hash map.
@@ -1593,6 +1601,16 @@ mod test {
         assert_eq!(Some(Arc::new(3)), map.pop_mut("baz"));
         map["bar"] = 8;
         assert_eq!(8, map["bar"]);
+    }
+
+    #[test]
+    fn macro_allows_trailing_comma() {
+        let map1 = hashmap!{"x" => 1, "y" => 2};
+        let map2 = hashmap!{
+            "x" => 1,
+            "y" => 2,
+        };
+        assert_eq!(map1, map2);
     }
 
     proptest! {

--- a/src/hashset.rs
+++ b/src/hashset.rs
@@ -54,6 +54,14 @@ macro_rules! hashset {
         )*
             l
     }};
+
+    ( $($x:expr ,)* ) => {{
+        let mut l = $crate::hashset::HashSet::new();
+        $(
+            l.insert_mut($x);
+        )*
+            l
+    }};
 }
 
 /// A hash set.
@@ -730,6 +738,16 @@ mod test {
         assert!(!set.contains("bar"));
         set.remove_mut("foo");
         assert!(!set.contains("foo"));
+    }
+
+    #[test]
+    fn macro_allows_trailing_comma() {
+        let set1 = hashset!{"foo", "bar"};
+        let set2 = hashset!{
+            "foo",
+            "bar",
+        };
+        assert_eq!(set1, set2);
     }
 
     proptest! {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -65,6 +65,14 @@ macro_rules! vector {
         )*
             l
     }};
+
+    ( $($x:expr ,)* ) => {{
+        let mut l = $crate::vector::Vector::new();
+        $(
+            l.push_back_mut($x);
+        )*
+            l
+    }};
 }
 
 #[derive(Clone, Copy)]
@@ -1452,6 +1460,15 @@ mod test {
     #[test]
     fn vector_singleton() {
         assert_eq!(Vector::singleton(5).len(), 1);
+    }
+
+    #[test]
+    fn macro_allows_trailing_comma() {
+        let vec1 = vector![1, 2, 3];
+        let vec2 = vector![
+            1, 2, 3,
+        ];
+        assert_eq!(vec1, vec2);
     }
 
     proptest! {


### PR DESCRIPTION
This is useful because `rustfmt` adds trailing commas to multi-line lists.