### PR TITLE
Allow for dropping all elements with chunk.drop_left(chunk.len()).

### DIFF
--- a/src/nodes/unsafe_chunks/chunk.rs
+++ b/src/nodes/unsafe_chunks/chunk.rs
@@ -176,7 +176,7 @@ impl<A> Chunk<A> {
     /// Remove all elements up to but not including `index`.
     pub fn drop_left(&mut self, index: usize) {
         if index > 0 {
-            if index >= self.len() {
+            if index > self.len() {
                 panic!("Chunk::drop_left: index out of bounds");
             }
             let start = self.left;


### PR DESCRIPTION
This is analogous to chunk.drop_right.