### PR TITLE
Bounds-check arguments before doing arithmetic with them.

### DIFF
--- a/src/nodes/unsafe_chunks/chunk.rs
+++ b/src/nodes/unsafe_chunks/chunk.rs
@@ -246,10 +246,10 @@ impl<A> Chunk<A> {
         if self.is_full() {
             panic!("Chunk::insert: chunk is full");
         }
-        let real_index = index + self.left;
-        if real_index < self.left || real_index > self.right {
+        if index > self.len() {
             panic!("Chunk::insert: index out of bounds");
         }
+        let real_index = index + self.left;
         let left_size = index;
         let right_size = self.right - real_index;
         if self.right == CHUNK_SIZE || (self.left > 0 && left_size < right_size) {
@@ -268,10 +268,10 @@ impl<A> Chunk<A> {
     }
 
     pub fn remove(&mut self, index: usize) -> A {
-        let real_index = index + self.left;
-        if real_index < self.left || real_index >= self.right {
+        if index >= self.len() {
             panic!("Chunk::remove: index out of bounds");
         }
+        let real_index = index + self.left;
         let value = unsafe { Chunk::force_read(real_index, self) };
         let left_size = index;
         let right_size = self.right - real_index - 1;
@@ -287,21 +287,19 @@ impl<A> Chunk<A> {
 
     #[inline]
     pub fn get(&self, index: usize) -> Option<&A> {
-        let real_index = self.left + index;
-        if real_index >= self.right {
-            None
+        if index < self.len() {
+            Some(&self.values[self.left + index])
         } else {
-            Some(&self.values[real_index])
+            None
         }
     }
 
     #[inline]
     pub fn get_mut(&mut self, index: usize) -> Option<&mut A> {
-        let real_index = self.left + index;
-        if real_index >= self.right {
-            None
+        if index < self.len() {
+            Some(&mut self.values[self.left + index])
         } else {
-            Some(&mut self.values[real_index])
+            None
         }
     }
 

--- a/src/nodes/unsafe_chunks/chunk.rs
+++ b/src/nodes/unsafe_chunks/chunk.rs
@@ -62,6 +62,7 @@ impl<A> Chunk<A> {
     }
 
     pub fn pair(left: A, right: A) -> Self {
+        debug_assert!(CHUNK_SIZE >= 2);
         let mut chunk: Self;
         unsafe {
             chunk = mem::uninitialized();


### PR DESCRIPTION
The checks in insert/remove were still catching all out-of-bounds
accesses (assuming usize overflow behaves like C size_t); but with
get/get_mut we could access uninitialized memory.