### PR TITLE
Handle empty size table in Node::len()

### DIFF
--- a/src/nodes/rrb.rs
+++ b/src/nodes/rrb.rs
@@ -340,7 +340,7 @@ impl<A: Clone> Node<A> {
     pub fn len(&self) -> usize {
         match self.children {
             Entry::Nodes(Size::Size(size), _) => size,
-            Entry::Nodes(Size::Table(ref size_table), _) => *(size_table.last().unwrap()),
+            Entry::Nodes(Size::Table(ref size_table), _) => *(size_table.last().unwrap_or(&0)),
             Entry::Values(ref values) => values.len(),
             Entry::Empty => 0,
         }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -2537,6 +2537,23 @@ mod test {
         vec1.append(vec2);
     }
 
+    #[test]
+    fn issue_67() {
+        let mut l = Vector::unit(4100);
+        for i in (0..4099).rev() {
+            let mut tmp = Vector::unit(i);
+            tmp.append(l);
+            l = tmp;
+        }
+        assert_eq!(4100, l.len());
+        let len = l.len();
+        let tail = l.slice(1..len);
+        assert_eq!(1, l.len());
+        assert_eq!(4099, tail.len());
+        assert_eq!(Some(&0), l.get(0));
+        assert_eq!(Some(&1), tail.get(0));
+    }
+
     proptest! {
         #[test]
         fn iter(ref vec in vec(i32::ANY, 0..1000)) {


### PR DESCRIPTION
Closes #67 

I don't know if this change is what we want for all cases, but it does seem to do the right thing here.