### PR TITLE
Update RRB size table after draining in push_chunk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,7 @@
 
 #![deny(unsafe_code)]
 #![cfg_attr(has_specialisation, feature(specialization))]
+#![feature(stmt_expr_attributes)]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
When a chunk does not fully fit in a node, we drain as many elements from the
chunk into the node and later push the leftover chunk to a sibling.

This commit makes sure that the size field of the parent node is updated
correctly. For dense nodes, we can simply add the number of drained elements to
the size. If there is a size table, we add that number to the size entry
corresponding to the current element and all entries to the right.

Closes #74