### PR TITLE
Fix RRB target index lookup

### DIFF
--- a/src/nodes/rrb.rs
+++ b/src/nodes/rrb.rs
@@ -434,7 +434,7 @@ impl<A: Clone> Node<A> {
             return None;
         }
         if let Entry::Nodes(Size::Table(ref size_table), _) = self.children {
-            if size_table[target_idx] <= index {
+            while size_table[target_idx] <= index {
                 target_idx += 1;
                 if target_idx >= size_table.len() {
                     return None;


### PR DESCRIPTION
When a size table contained too many sparse nodes, the index computation would
occasionally be slightly off.

This would happen for example for a node with a size table (1, 2, 3) - that is three chunks, each of length one.
`index_in(_, 2)` would return the index of the middle chunk although the element at index 2 is clearly in the third chunk.
I have a large trace where this occurs. It should be possible to create a small test case.

Alternatively, we could maintain an invariant
`size_table[(index / NODE_SIZE.pow(level)) + 1] > index`
but this seemed easier.