### PR TITLE
Update clippy.toml to work on both stable and nighly toolchains

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,4 @@
 blacklisted-names = []
-cyclomatic-complexity-threshold = 100
 single-char-binding-names-threshold = 15
 # I HAVE THE POWER OF OLEG
 type-complexity-threshold = 999999


### PR DESCRIPTION
On `clippy 0.0.212 (92612c9 2019-03-18)`:

```text
error: error reading Clippy's configuration file `/home/pzmarzly/im-rs/clippy.toml`: found deprecated field `cyclomatic-complexity-threshold`. Please use `cognitive-complexity-threshold` instead.
```

Renaming the field makes clippy happy both on `0.0.212 (92612c9 2019-03-18)` (nightly) and `0.0.212 (1b89724 2019-01-15)` (stable).