### PR TITLE
Ring buffer backed RRB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,19 +23,25 @@ The minimum supported Rust version is now 1.34.0.
 
 ### Removed
 
+- `Vector::leaves` and `Vector::leaves_mut` have been removed, as they can no
+  longer be implemented without exposing the underlying chunk type.
+- The deprecated methods `Vector::chunks` and `Vector::chunks_mut`,
+  corresponding to the above mentioned `leaves` and `leaves_mut`, have also been
+  removed. (#50)
 - The deprecated `singleton` constructors have been removed. Please use `unit`
   instead.
-- The deprecated methods `Vector::chunks` and `Vector::chunks_mut` have been
-  removed in favour of `Vector::leaves` and `Vector::leaves_mut` respectively.
-  (#50)
-- The deprecated reference to [`sized-chunks`](https://crates.io/crates/sized-chunks)
-  has been removed. If you need it, please use the `sized-chunks` crate directly.
+- The deprecated reference to
+  [`sized-chunks`](https://crates.io/crates/sized-chunks) has been removed. If
+  you need it, please use the `sized-chunks` crate directly.
 - `im::iter::unfold_mut` has been removed, as there's no meaningful difference
   between it and rust-std 1.34.0's `std::iter::from_fn` with a captured state
   variable.
 
 ### Fixed
 
+- `Vector` is now backed by a `sized_chunks::RingBuffer` rather than a
+  `sized_chunks::Chunk`. This doesn't impact benchmark performance appreciably,
+  but should yield some minor speed boosts for edge cases.
 - Some complexity timings have been added and corrected. (#87)
 - `OrdSet::is_subset(&self, other)` now returns immediately when `self` is
   larger than `other` and thus could not possibly be a subset of it. (#87)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The minimum supported Rust version is now 1.34.0.
 - `im::iter::unfold` now gives you the owned state value rather than an
   immutable reference to it, which makes it a little more useful.
 
+### Added
+
+- 'Focus::get' and its mutable counterparts now correctly return references with
+  the lifetime of the underlying `Vector` rather than the lifetime of the
+  `Focus`.
+
 ### Removed
 
 - The deprecated `singleton` constructors have been removed. Please use `unit`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustc_version = "0.2"
 
 [dependencies]
 typenum = "1.10"
-sized-chunks = "0.2.0"
+sized-chunks = "0.2.2"
 quickcheck = { version = "0.8", optional = true }
 proptest = { version = "0.9", optional = true }
 serde = { version = "1.0", optional = true }

--- a/benches/vector.rs
+++ b/benches/vector.rs
@@ -20,8 +20,8 @@ fn rando<A>() -> impl Iterator<Item = A>
 where
     Standard: Distribution<A>,
 {
-    let rng = rand::thread_rng();
-    std::iter::from_fn(|| Some(rng.gen()))
+    let mut rng = rand::thread_rng();
+    std::iter::from_fn(move || Some(rng.gen()))
 }
 
 fn vector_push_front_mut(b: &mut Bencher, count: usize) {

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -13,7 +13,9 @@ pub mod chunk {
     use sized_chunks as sc;
     use typenum::Unsigned;
 
-    pub type Chunk<A> = sc::sized_chunk::Chunk<A, VectorChunkSize>;
-    pub type Iter<A> = sc::sized_chunk::Iter<A, VectorChunkSize>;
+    pub type Chunk<A> = sc::ring_buffer::RingBuffer<A, VectorChunkSize>;
+    pub type Slice<'a, A> = sc::ring_buffer::Slice<'a, A, VectorChunkSize>;
+    pub type SliceMut<'a, A> = sc::ring_buffer::SliceMut<'a, A, VectorChunkSize>;
+    pub type Iter<A> = sc::ring_buffer::OwnedIter<A, VectorChunkSize>;
     pub const CHUNK_SIZE: usize = VectorChunkSize::USIZE;
 }

--- a/src/nodes/rrb.rs
+++ b/src/nodes/rrb.rs
@@ -92,7 +92,7 @@ impl Size {
                 match side {
                     Left => {
                         let first = size_table.pop_front();
-                        debug_assert_eq!(value, first);
+                        debug_assert_eq!(value, first.unwrap());
                         for entry in size_table.iter_mut() {
                             *entry -= value;
                         }
@@ -100,7 +100,7 @@ impl Size {
                     Right => {
                         let pop = size_table.pop_back();
                         let last = size_table.last().unwrap_or(&0);
-                        debug_assert_eq!(value, pop - last);
+                        debug_assert_eq!(value, pop.unwrap() - last);
                     }
                 }
             }
@@ -519,8 +519,8 @@ impl<A: Clone> Node<A> {
     fn pop_child_node(&mut self, side: Side) -> Ref<Node<A>> {
         let children = self.children.unwrap_nodes_mut();
         match side {
-            Left => children.pop_front(),
-            Right => children.pop_back(),
+            Left => children.pop_front().unwrap(),
+            Right => children.pop_back().unwrap(),
         }
     }
 
@@ -938,7 +938,7 @@ impl<A: Clone> Node<A> {
                     let right_node = Ref::make_mut(&mut right);
                     let left_last =
                         if let Entry::Nodes(ref mut size, ref mut children) = left_node.children {
-                            let node = Ref::make_mut(children).pop_back();
+                            let node = Ref::make_mut(children).pop_back().unwrap();
                             size.pop(Side::Right, node.len());
                             node
                         } else {
@@ -946,7 +946,7 @@ impl<A: Clone> Node<A> {
                         };
                     let right_first =
                         if let Entry::Nodes(ref mut size, ref mut children) = right_node.children {
-                            let node = Ref::make_mut(children).pop_front();
+                            let node = Ref::make_mut(children).pop_front().unwrap();
                             size.pop(Side::Left, node.len());
                             node
                         } else {
@@ -1061,7 +1061,7 @@ impl<A: Clone> Iterator for ConsumingIter<A> {
         if let Some(ref mut chunk) = self.front_chunk {
             if !chunk.is_empty() {
                 self.remaining -= 1;
-                return Some(chunk.pop_front());
+                return chunk.pop_front();
             }
         }
         match self.root.pop_chunk(self.level, Side::Left) {
@@ -1071,7 +1071,7 @@ impl<A: Clone> Iterator for ConsumingIter<A> {
                 if let Some(ref mut chunk) = self.back_chunk {
                     if !chunk.is_empty() {
                         self.remaining -= 1;
-                        return Some(chunk.pop_front());
+                        return chunk.pop_front();
                     } else {
                         return None;
                     }
@@ -1094,7 +1094,7 @@ impl<A: Clone> DoubleEndedIterator for ConsumingIter<A> {
         if let Some(ref mut chunk) = self.back_chunk {
             if !chunk.is_empty() {
                 self.remaining -= 1;
-                return Some(chunk.pop_back());
+                return chunk.pop_back();
             }
         }
         match self.root.pop_chunk(self.level, Side::Left) {
@@ -1104,7 +1104,7 @@ impl<A: Clone> DoubleEndedIterator for ConsumingIter<A> {
                 if let Some(ref mut chunk) = self.front_chunk {
                     if !chunk.is_empty() {
                         self.remaining -= 1;
-                        return Some(chunk.pop_back());
+                        return chunk.pop_back();
                     } else {
                         return None;
                     }

--- a/src/vector/focus.rs
+++ b/src/vector/focus.rs
@@ -127,7 +127,7 @@ where
     }
 
     /// Get a reference to the value at a given index.
-    pub fn get(&mut self, index: usize) -> Option<&A> {
+    pub fn get(&mut self, index: usize) -> Option<&'a A> {
         match self {
             Focus::Empty => None,
             Focus::Single(slice) => slice.get(index),
@@ -138,7 +138,7 @@ where
     /// Get a reference to the value at a given index.
     ///
     /// Panics if the index is out of bounds.
-    pub fn index(&mut self, index: usize) -> &A {
+    pub fn index(&mut self, index: usize) -> &'a A {
         self.get(index).expect("index out of bounds")
     }
 
@@ -362,11 +362,11 @@ where
     }
 
     #[allow(unsafe_code)]
-    fn get_focus(&self) -> &Chunk<A> {
+    fn get_focus<'a>(&self) -> &'a Chunk<A> {
         unsafe { &*self.target_ptr }
     }
 
-    fn get(&mut self, index: usize) -> Option<&A> {
+    fn get<'a>(&mut self, index: usize) -> Option<&'a A> {
         if index >= self.len() {
             return None;
         }
@@ -480,12 +480,12 @@ where
     }
 
     /// Get a reference to the value at a given index.
-    pub fn get(&mut self, index: usize) -> Option<&A> {
+    pub fn get(&mut self, index: usize) -> Option<&'a A> {
         self.get_mut(index).map(|r| &*r)
     }
 
     /// Get a mutable reference to the value at a given index.
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut A> {
+    pub fn get_mut(&mut self, index: usize) -> Option<&'a mut A> {
         match self {
             FocusMut::Empty => None,
             FocusMut::Single(chunk) => chunk.get_mut(index),
@@ -836,11 +836,11 @@ where
     }
 
     #[allow(unsafe_code)]
-    fn get_focus(&mut self) -> &mut Chunk<A> {
+    fn get_focus(&mut self) -> &'a mut Chunk<A> {
         unsafe { &mut *self.target_ptr.load(Ordering::Relaxed) }
     }
 
-    fn get(&mut self, index: usize) -> Option<&mut A> {
+    fn get(&mut self, index: usize) -> Option<&'a mut A> {
         if index >= self.len() {
             return None;
         }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -293,36 +293,6 @@ impl<A: Clone> Vector<A> {
         IterMut::new(self)
     }
 
-    /// Get an iterator over the leaf nodes of a vector.
-    ///
-    /// This returns an iterator over the [`Chunk`s][Chunk] at the leaves of the
-    /// RRB tree. These are useful for efficient parallelisation of work on
-    /// the vector, but should not be used for basic iteration.
-    ///
-    /// Time: O(1)
-    ///
-    /// [Chunk]: ../chunk/struct.Chunk.html
-    #[inline]
-    #[must_use]
-    pub fn leaves(&self) -> Chunks<'_, A> {
-        Chunks::new(self)
-    }
-
-    /// Get a mutable iterator over the leaf nodes of a vector.
-    //
-    /// This returns an iterator over the [`Chunk`s][Chunk] at the leaves of the
-    /// RRB tree. These are useful for efficient parallelisation of work on
-    /// the vector, but should not be used for basic iteration.
-    ///
-    /// Time: O(1)
-    ///
-    /// [Chunk]: ../chunk/struct.Chunk.html
-    #[inline]
-    #[must_use]
-    pub fn leaves_mut(&mut self) -> ChunksMut<'_, A> {
-        ChunksMut::new(self)
-    }
-
     /// Construct a [`Focus`][Focus] for a vector.
     ///
     /// Time: O(1)
@@ -834,7 +804,7 @@ impl<A: Clone> Vector<A> {
         } else {
             match self {
                 Empty => None,
-                Single(chunk) => Some(Ref::make_mut(chunk).pop_front()),
+                Single(chunk) => Ref::make_mut(chunk).pop_front(),
                 Full(tree) => tree.pop_front(),
             }
         }
@@ -861,7 +831,7 @@ impl<A: Clone> Vector<A> {
         } else {
             match self {
                 Empty => None,
-                Single(chunk) => Some(Ref::make_mut(chunk).pop_back()),
+                Single(chunk) => Ref::make_mut(chunk).pop_back(),
                 Full(tree) => tree.pop_back(),
             }
         }
@@ -1453,7 +1423,7 @@ impl<A: Clone> RRB<A> {
         }
         self.length -= 1;
         let outer_f = Ref::make_mut(&mut self.outer_f);
-        Some(outer_f.pop_front())
+        outer_f.pop_front()
     }
 
     fn pop_back(&mut self) -> Option<A> {
@@ -1477,7 +1447,7 @@ impl<A: Clone> RRB<A> {
         }
         self.length -= 1;
         let outer_b = Ref::make_mut(&mut self.outer_b);
-        Some(outer_b.pop_back())
+        outer_b.pop_back()
     }
 
     fn push_front(&mut self, value: A) {
@@ -2021,123 +1991,6 @@ impl<A: Clone> ExactSizeIterator for ConsumingIter<A> {}
 
 impl<A: Clone> FusedIterator for ConsumingIter<A> {}
 
-/// An iterator over the leaf nodes of a vector.
-///
-/// To obtain one, use [`Vector::chunks()`][chunks].
-///
-/// [chunks]: enum.Vector.html#method.chunks
-pub struct Chunks<'a, A: 'a> {
-    focus: Focus<'a, A>,
-    front_index: usize,
-    back_index: usize,
-}
-
-impl<'a, A: Clone> Chunks<'a, A> {
-    fn new(seq: &'a Vector<A>) -> Self {
-        Chunks {
-            focus: seq.focus(),
-            front_index: 0,
-            back_index: seq.len(),
-        }
-    }
-}
-
-impl<'a, A: Clone> Iterator for Chunks<'a, A> {
-    type Item = &'a [A];
-
-    /// Advance the iterator and return the next value.
-    ///
-    /// Time: O(1)*
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.front_index >= self.back_index {
-            return None;
-        }
-        #[allow(unsafe_code)]
-        let focus: &'a mut Focus<'a, A> = unsafe { &mut *(&mut self.focus as *mut _) };
-        let (range, value) = focus.chunk_at(self.front_index);
-        self.front_index = range.end;
-        Some(value)
-    }
-}
-
-impl<'a, A: Clone> DoubleEndedIterator for Chunks<'a, A> {
-    /// Remove and return an element from the back of the iterator.
-    ///
-    /// Time: O(1)*
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.front_index >= self.back_index {
-            return None;
-        }
-        self.back_index -= 1;
-        #[allow(unsafe_code)]
-        let focus: &'a mut Focus<'a, A> = unsafe { &mut *(&mut self.focus as *mut _) };
-        let (range, value) = focus.chunk_at(self.back_index);
-        self.back_index = range.start;
-        Some(value)
-    }
-}
-
-impl<'a, A: Clone> FusedIterator for Chunks<'a, A> {}
-
-/// A mutable iterator over the leaf nodes of a vector.
-///
-/// To obtain one, use [`Vector::chunks_mut()`][chunks_mut].
-///
-/// [chunks_mut]: enum.Vector.html#method.chunks_mut
-pub struct ChunksMut<'a, A: 'a> {
-    focus: FocusMut<'a, A>,
-    front_index: usize,
-    back_index: usize,
-}
-
-impl<'a, A: Clone> ChunksMut<'a, A> {
-    fn new(seq: &'a mut Vector<A>) -> Self {
-        let len = seq.len();
-        ChunksMut {
-            focus: seq.focus_mut(),
-            front_index: 0,
-            back_index: len,
-        }
-    }
-}
-
-impl<'a, A: Clone> Iterator for ChunksMut<'a, A> {
-    type Item = &'a mut [A];
-
-    /// Advance the iterator and return the next value.
-    ///
-    /// Time: O(1)*
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.front_index >= self.back_index {
-            return None;
-        }
-        #[allow(unsafe_code)]
-        let focus: &'a mut FocusMut<'a, A> = unsafe { &mut *(&mut self.focus as *mut _) };
-        let (range, value) = focus.chunk_at(self.front_index);
-        self.front_index = range.end;
-        Some(value)
-    }
-}
-
-impl<'a, A: Clone> DoubleEndedIterator for ChunksMut<'a, A> {
-    /// Remove and return an element from the back of the iterator.
-    ///
-    /// Time: O(1)*
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.front_index >= self.back_index {
-            return None;
-        }
-        self.back_index -= 1;
-        #[allow(unsafe_code)]
-        let focus: &'a mut FocusMut<'a, A> = unsafe { &mut *(&mut self.focus as *mut _) };
-        let (range, value) = focus.chunk_at(self.back_index);
-        self.back_index = range.start;
-        Some(value)
-    }
-}
-
-impl<'a, A: Clone> FusedIterator for ChunksMut<'a, A> {}
-
 // Rayon
 
 #[cfg(all(threadsafe, any(test, feature = "rayon")))]
@@ -2573,14 +2426,26 @@ mod test {
     #[test]
     fn issue_77() {
         let mut x = Vector::new();
-        for _ in 0..44 { x.push_back(0); }
-        for _ in 0..20 { x.insert(0, 0); }
+        for _ in 0..44 {
+            x.push_back(0);
+        }
+        for _ in 0..20 {
+            x.insert(0, 0);
+        }
         x.insert(1, 0);
-        for _ in 0..441 { x.push_back(0); }
-        for _ in 0..58 { x.insert(0, 0); }
+        for _ in 0..441 {
+            x.push_back(0);
+        }
+        for _ in 0..58 {
+            x.insert(0, 0);
+        }
         x.insert(514, 0);
-        for _ in 0..73 { x.push_back(0); }
-        for _ in 0..10 { x.insert(0, 0); }
+        for _ in 0..73 {
+            x.push_back(0);
+        }
+        for _ in 0..10 {
+            x.insert(0, 0);
+        }
         x.insert(514, 0);
     }
 
@@ -2746,26 +2611,6 @@ mod test {
 
             let expected: Vector<i32> = input.clone().into_iter().map(|i| i.overflowing_add(1).0).collect();
             assert_eq!(expected, vec);
-        }
-
-        #[test]
-        fn chunks(ref input in vector(i32::ANY, 0..10000)) {
-            let output: Vector<_> = input.leaves().flat_map(|a|a).cloned().collect();
-            assert_eq!(input, &output);
-            let rev_in: Vector<_> = input.iter().rev().cloned().collect();
-            let rev_out: Vector<_> = input.leaves().rev().map(|c| c.iter().rev()).flat_map(|a|a).cloned().collect();
-            assert_eq!(rev_in, rev_out);
-        }
-
-        #[test]
-        fn chunks_mut(ref mut input_src in vector(i32::ANY, 0..10000)) {
-            let mut input = input_src.clone();
-            #[allow(clippy::map_clone)]
-            let output: Vector<_> = input.leaves_mut().flat_map(|a| a).map(|v| *v).collect();
-            assert_eq!(input, output);
-            let rev_in: Vector<_> = input.iter().rev().cloned().collect();
-            let rev_out: Vector<_> = input.leaves_mut().rev().map(|c| c.iter().rev()).flat_map(|a|a).cloned().collect();
-            assert_eq!(rev_in, rev_out);
         }
 
         // The following two tests are very slow and there are unit tests above

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1812,9 +1812,7 @@ impl<'a, A: Clone> Iterator for Iter<'a, A> {
         if self.front_index >= self.back_index {
             return None;
         }
-        #[allow(unsafe_code)]
-        let focus: &'a mut Focus<'a, A> = unsafe { &mut *(&mut self.focus as *mut _) };
-        let value = focus.get(self.front_index);
+        let value = self.focus.get(self.front_index);
         self.front_index += 1;
         value
     }
@@ -1834,9 +1832,7 @@ impl<'a, A: Clone> DoubleEndedIterator for Iter<'a, A> {
             return None;
         }
         self.back_index -= 1;
-        #[allow(unsafe_code)]
-        let focus: &'a mut Focus<'a, A> = unsafe { &mut *(&mut self.focus as *mut _) };
-        focus.get(self.back_index)
+        self.focus.get(self.back_index)
     }
 }
 


### PR DESCRIPTION
This replaces `sized_chunks::Chunk` with `sized_chunks::RingBuffer` as the node chunk type. It doesn't impact benchmarks much, as `Chunk` was already optimised for the benchmarking basics like repeatedly pushing and popping, but should make nontrivial compound ops on `Vector` marginally faster.