### PR TITLE
Fix quadratic worst case in quicksort for Vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,13 @@ quickcheck = { version = "0.9", optional = true }
 proptest = { version = "0.9", optional = true }
 serde = { version = "1.0", optional = true }
 rayon = { version = "1.0", optional = true }
+rand = { version = "0.7", features = ["small_rng"] }
 
 [dev-dependencies]
 proptest = "0.9"
 serde = "1.0"
 serde_json = "1.0"
 rayon = "1.0"
-rand = { version = "0.7", features = ["small_rng"] }
 pretty_assertions = "0.6"
 metrohash = "1.0.6"
 proptest-derive = "0.1.0"

--- a/rc/Cargo.toml
+++ b/rc/Cargo.toml
@@ -29,13 +29,13 @@ quickcheck = { version = "0.9", optional = true }
 proptest = { version = "0.9", optional = true }
 serde = { version = "1.0", optional = true }
 rayon = { version = "1.0", optional = true }
+rand = { version = "0.7", features = ["small_rng"] }
 
 [dev-dependencies]
 proptest = "0.9"
 serde = "1.0"
 serde_json = "1.0"
 rayon = "1.0"
-rand = { version = "0.7", features = ["small_rng"] }
 pretty_assertions = "0.6"
 metrohash = "1.0.6"
 proptest-derive = "0.1.0"

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -8,7 +8,7 @@ use rand::prelude::*;
 
 // Ported from the Java version at:
 //    http://www.cs.princeton.edu/~rs/talks/QuicksortIsOptimal.pdf
-// Should be O(n log n) expected 
+// Should be O(n) to O(n log n)
 pub fn do_quicksort<A, F, R>(vector: &mut FocusMut<A>, left: usize, right: usize, cmp: &F, rng: &mut R)
 where
     A: Clone,

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -4,14 +4,16 @@
 
 use crate::vector::FocusMut;
 use std::cmp::Ordering;
+use rand::prelude::*;
 
 // Ported from the Java version at:
 //    http://www.cs.princeton.edu/~rs/talks/QuicksortIsOptimal.pdf
-// Should be O(n) to O(n log n)
-pub fn quicksort<A, F>(vector: &mut FocusMut<A>, left: usize, right: usize, cmp: &F)
+// Should be O(n log n) expected 
+pub fn do_quicksort<A, F, R>(vector: &mut FocusMut<A>, left: usize, right: usize, cmp: &F, rng: &mut R)
 where
     A: Clone,
     F: Fn(&A, &A) -> Ordering,
+    R: Rng
 {
     if right <= left {
         return;
@@ -19,10 +21,13 @@ where
 
     let l = left as isize;
     let r = right as isize;
+    let p = rng.gen_range(l, r + 1);
     let mut l1 = l;
     let mut r1 = r;
     let mut l2 = l - 1;
     let mut r2 = r;
+
+    vector.swap(r as usize, p as usize);
     loop {
         while l1 != r && vector.pair(l1 as usize, r as usize, |a, b| cmp(a, b)) == Ordering::Less {
             l1 += 1;
@@ -65,9 +70,18 @@ where
     }
 
     if r1 >= 0 {
-        quicksort(vector, left, r1 as usize, cmp);
+        do_quicksort(vector, left, r1 as usize, cmp, rng);
     }
-    quicksort(vector, l1 as usize, right, cmp);
+    do_quicksort(vector, l1 as usize, right, cmp, rng);
+}
+
+pub fn quicksort<A, F>(vector: &mut FocusMut<A>, left: usize, right: usize, cmp: &F)
+where
+    A: Clone,
+    F: Fn(&A, &A) -> Ordering,
+{
+    let mut rng = rand::thread_rng();
+    do_quicksort(vector, left, right, cmp, &mut rng);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes a quadratic worst case scenario by choosing a random pivot instead of just the last entry in the Vector.

Some benchmarks can be seen here: https://gist.github.com/nomad010/b83cc9b50193212532f02fbb309fd568

In most cases, this won't actually affect performance very much, but in cases where the Vector is sorted/mostly sorted, it will affect it dramatically for the better.

The downsides to this fix are that it adds another dependency (rand), however I think that the improvement that comes with it more than make up for that.
