### PR TITLE
Switch to `version_check` from `rustc_version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ path = "./src/lib.rs"
 circle-ci = { repository = "bodil/im-rs" }
 
 [build-dependencies]
-rustc_version = "0.2"
+version_check = "0.9"
 
 [dependencies]
 typenum = "1.10"
 bitmaps = "2.0.0"
-sized-chunks = { path = "../sized-chunks" }
+sized-chunks = { version = "*" }
 quickcheck = { version = "0.9", optional = true }
 proptest = { version = "0.9", optional = true }
 serde = { version = "1.0", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -2,18 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-extern crate rustc_version;
-
-use rustc_version::{version_meta, Channel};
 use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    match version_meta().unwrap().channel {
-        Channel::Nightly => {
+    if let Some(channel) = version_check::Channel::read() {
+        if channel.supports_features() {
             println!("cargo:rustc-cfg=has_specialisation");
         }
-        _ => (),
     }
     let pkgname = env::var("CARGO_PKG_NAME").expect("Cargo didn't set the CARGO_PKG_NAME env var!");
     let test_rc = env::var("IM_TEST_RC").is_ok();

--- a/rc/Cargo.toml
+++ b/rc/Cargo.toml
@@ -20,7 +20,7 @@ path = "../src/lib.rs"
 travis-ci = { repository = "bodil/im-rs" }
 
 [build-dependencies]
-rustc_version = "0.2"
+version_check = "0.9"
 
 [dependencies]
 typenum = "1.10"


### PR DESCRIPTION
Currently `rustc_version` has a dependency on `semver`, which can
sometimes be a bit of a weighty crate to build (if its `serde` feature
is enabled). This instead switches to a similar crate, `version_check`,
to check in the build script to see if it's a nightly rustc compiler.