### PR TITLE
An integer overflow issue when splitting the vector

### DIFF
--- a/src/tests/vector.rs
+++ b/src/tests/vector.rs
@@ -217,3 +217,16 @@ proptest! {
         }
     }
 }
+
+#[test]
+fn split_off_causes_overflow() {
+    let mut vec = Vector::new();
+
+    for i in 0..6000 {
+        vec.push_back(i);
+    }
+
+    while vec.len() > 64 {
+        vec = vec.split_off(64)
+    }
+}


### PR DESCRIPTION
Hi @bodil! I am working on the master's thesis about Rust and persistent vector based on RRB trees, and I have discovered a bug while benchmarking the im-rs implementation. The PR contains a unit test which reproduces the issue. Thanks!