### PR TITLE
Fix minor typo in docs

### DIFF
--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -4,7 +4,7 @@
 
 //! An unordered map.
 //!
-//! An immutable hash map using [hash array mapped tries] [1].
+//! An immutable hash map using [hash array mapped tries][1].
 //!
 //! Most operations on this map are O(log<sub>x</sub> n) for a
 //! suitably high *x* that it should be nearly O(1) for most maps.


### PR DESCRIPTION
There's a stray space character in `[hash array mapped tries] [1]`, which makes [the brackets visible in the docs](https://docs.rs/im/14.0.0/im/hashmap/index.html).

By the way, thanks for making such a great library!