### PR TITLE
recognize identical node during Ordmap::diff

### DIFF
--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -1144,18 +1144,20 @@ where
                 },
                 (Some(old), Some(new)) => match (old, new) {
                     (IterItem::Consider(old), IterItem::Consider(new)) => {
-                        match old.keys[0].cmp_values(&new.keys[0]) {
-                            Ordering::Less => {
-                                Self::push(&mut self.old_stack, &old);
-                                self.new_stack.push(IterItem::Consider(new));
-                            }
-                            Ordering::Greater => {
-                                self.old_stack.push(IterItem::Consider(old));
-                                Self::push(&mut self.new_stack, &new);
-                            }
-                            Ordering::Equal => {
-                                Self::push(&mut self.old_stack, &old);
-                                Self::push(&mut self.new_stack, &new);
+                        if !std::ptr::eq(old, new) {
+                            match old.keys[0].cmp_values(&new.keys[0]) {
+                                Ordering::Less => {
+                                    Self::push(&mut self.old_stack, &old);
+                                    self.new_stack.push(IterItem::Consider(new));
+                                }
+                                Ordering::Greater => {
+                                    self.old_stack.push(IterItem::Consider(old));
+                                    Self::push(&mut self.new_stack, &new);
+                                }
+                                Ordering::Equal => {
+                                    Self::push(&mut self.old_stack, &old);
+                                    Self::push(&mut self.new_stack, &new);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
If two nodes are actually the very same node, they will have identical
content since... well... it is identical to itself. We update the
OrdMap::diff code detect such case and simply skip over such node since
they won't raise any difference.

I pushed this to github mostly to start testing this on a wider set of machine/data. However I feel like it i useful to show this early. 