### PR TITLE
Rework the sort method to be more efficient for vectors.

### DIFF
--- a/src/sort.rs
+++ b/src/sort.rs
@@ -86,10 +86,10 @@ where
     let mut less_position = 0;
     let mut equal_position = 0;
     let mut greater_position = 0;
-    let mut equal_swap_side = None;
 
     while less_position != less_focus.len() || greater_position != greater_focus.len() {
         // At start of this loop, equal_position always points to an equal item
+        let mut equal_swap_side = None;
         let equal_item = equal_focus.index(equal_position);
 
         // Advance the less_position until we find an out of place item
@@ -191,7 +191,7 @@ mod test {
 
     proptest! {
         #[test]
-        fn test_quicksort(ref input in vector(i32::ANY, 0..5000)) {
+        fn test_quicksort(ref input in vector(i32::ANY, 0..10000)) {
             let mut vec = input.clone();
             let len = vec.len();
             if len > 1 {

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -191,7 +191,7 @@ mod test {
 
     proptest! {
         #[test]
-        fn test_quicksort(ref input in vector(i32::ANY, 0..1000)) {
+        fn test_quicksort(ref input in vector(i32::ANY, 0..5000)) {
             let mut vec = input.clone();
             let len = vec.len();
             if len > 1 {

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -5,6 +5,7 @@
 use crate::vector::FocusMut;
 use rand_core::{RngCore, SeedableRng};
 use std::cmp::Ordering;
+use std::mem;
 
 fn gen_range<R: RngCore>(rng: &mut R, min: usize, max: usize) -> usize {
     let range = max - min;
@@ -13,85 +14,171 @@ fn gen_range<R: RngCore>(rng: &mut R, min: usize, max: usize) -> usize {
 
 // Ported from the Java version at:
 //    http://www.cs.princeton.edu/~rs/talks/QuicksortIsOptimal.pdf
-// Should be O(n) to O(n log n)
-fn do_quicksort<A, F, R>(
-    vector: &mut FocusMut<'_, A>,
-    left: usize,
-    right: usize,
-    cmp: &F,
-    rng: &mut R,
-) where
+// There are a couple of modifications made here to make it more performant on the tree structure of
+// the Vector. Instead of moving of handling equal and nonequal items in a single pass we make two
+// additional passes to find the exact partition places. This allows us to split the focus into
+// three correctly sized parts for less than, equal to and greater than items. As a bonus this
+// doesn't need to reorder the equal items to the center of the vector.
+fn do_quicksort<A, F, R>(vector: FocusMut<'_, A>, cmp: &F, rng: &mut R)
+where
     A: Clone,
     F: Fn(&A, &A) -> Ordering,
     R: RngCore,
 {
-    if right <= left {
+    if vector.len() <= 1 {
         return;
     }
 
-    let l = left as isize;
-    let r = right as isize;
-    let p = gen_range(rng, left, right + 1) as isize;
-    let mut l1 = l;
-    let mut r1 = r;
-    let mut l2 = l - 1;
-    let mut r2 = r;
+    // We know there are at least 2 elements here
+    let pivot_index = gen_range(rng, 0, vector.len());
+    let (mut first, mut rest) = vector.split_at(1);
 
-    vector.swap(r as usize, p as usize);
-    loop {
-        while l1 != r && vector.pair(l1 as usize, r as usize, |a, b| cmp(a, b)) == Ordering::Less {
-            l1 += 1;
+    if pivot_index > 0 {
+        mem::swap(rest.index_mut(pivot_index - 1), first.index_mut(0));
+    }
+    // Pivot is now always in the first slice
+    let pivot_item = first.index(0);
+
+    // Find the exact place to put the pivot or pivot-equal items
+    let mut less_count = 0;
+    let mut equal_count = 0;
+
+    for index in 0..rest.len() {
+        let item = rest.index(index);
+        let comp = cmp(item, pivot_item);
+        match comp {
+            Ordering::Less => less_count += 1,
+            Ordering::Equal => equal_count += 1,
+            Ordering::Greater => {}
         }
-        r1 -= 1;
-        while r1 != r && vector.pair(r as usize, r1 as usize, |a, b| cmp(a, b)) == Ordering::Less {
-            if r1 == l {
-                break;
+    }
+
+    // If by accident we picked the minimum element as a pivot, we just call sort again with the
+    // rest of the vector.
+    if less_count == 0 {
+        do_quicksort(rest, cmp, rng);
+        return;
+    }
+
+    // We know here that there is at least one item before the pivot, so we move the minimum to the
+    // beginning part of the vector. First, however we swap the pivot to the start of the equal
+    // zone.
+    less_count -= 1;
+    equal_count += 1;
+    let first_item = first.index_mut(0);
+    mem::swap(first_item, rest.index_mut(less_count));
+    for index in 0..rest.len() {
+        if index == less_count {
+            // This is the position we swapped the pivot to. We can't move it from its position, and
+            // we know its not the minimum.
+            continue;
+        }
+        let rest_item = rest.index_mut(index);
+        if cmp(rest_item, first_item) == Ordering::Less {
+            mem::swap(first_item, rest_item);
+        }
+    }
+
+    // Split the vector up into less_than, equal to and greater than parts.
+    let (remaining, mut greater_focus) = rest.split_at(less_count + equal_count);
+    let (mut less_focus, mut equal_focus) = remaining.split_at(less_count);
+
+    let mut less_position = 0;
+    let mut equal_position = 0;
+    let mut greater_position = 0;
+    let mut equal_swap_side = None;
+
+    while less_position != less_focus.len() || greater_position != greater_focus.len() {
+        // At start of this loop, equal_position always points to an equal item
+        let equal_item = equal_focus.index(equal_position);
+
+        // Advance the less_position until we find an out of place item
+        while less_position != less_focus.len() {
+            let less_item = less_focus.index(less_position);
+            match cmp(less_item, equal_item) {
+                Ordering::Equal => {
+                    equal_swap_side = Some(Ordering::Less);
+                    break;
+                }
+                Ordering::Greater => {
+                    break;
+                }
+                _ => {}
             }
-            r1 -= 1;
+            less_position += 1;
         }
-        if l1 >= r1 {
-            break;
-        }
-        vector.swap(l1 as usize, r1 as usize);
-        if l1 != r && vector.pair(l1 as usize, r as usize, |a, b| cmp(a, b)) == Ordering::Equal {
-            l2 += 1;
-            vector.swap(l2 as usize, l1 as usize);
-        }
-        if r1 != r && vector.pair(r as usize, r1 as usize, |a, b| cmp(a, b)) == Ordering::Equal {
-            r2 -= 1;
-            vector.swap(r1 as usize, r2 as usize);
-        }
-    }
-    vector.swap(l1 as usize, r as usize);
 
-    r1 = l1 - 1;
-    l1 += 1;
-    let mut k = l;
-    while k < l2 {
-        vector.swap(k as usize, r1 as usize);
-        r1 -= 1;
-        k += 1;
-    }
-    k = r - 1;
-    while k > r2 {
-        vector.swap(l1 as usize, k as usize);
-        k -= 1;
-        l1 += 1;
+        // Advance the greater until we find an out of place item
+        while greater_position != greater_focus.len() {
+            let greater_item = greater_focus.index(greater_position);
+            match cmp(greater_item, equal_item) {
+                Ordering::Less => break,
+                Ordering::Equal => {
+                    equal_swap_side = Some(Ordering::Greater);
+                    break;
+                }
+                _ => {}
+            }
+            greater_position += 1;
+        }
+
+        if let Some(swap_side) = equal_swap_side {
+            // One of the sides is equal to the pivot, advance the pivot
+            let item = if swap_side == Ordering::Less {
+                less_focus.index_mut(less_position)
+            } else {
+                greater_focus.index_mut(greater_position)
+            };
+
+            // We are guaranteed not to hit the end of the equal focus
+            while cmp(item, equal_focus.index(equal_position)) == Ordering::Equal {
+                equal_position += 1;
+            }
+
+            // Swap the equal position and the desired side, it's important to note that only the
+            // equals focus is guaranteed to have made progress so we don't advance the side's index
+            mem::swap(item, equal_focus.index_mut(equal_position));
+        } else if less_position != less_focus.len() && greater_position != greater_focus.len() {
+            // Both sides are out of place and not equal to the pivot, this can only happen if there
+            // is a greater item in the lesser zone and a lesser item in the greater zone. The
+            // solution is to swap both sides and advance both side's indices.
+            debug_assert_ne!(
+                cmp(
+                    less_focus.index(less_position),
+                    equal_focus.index(equal_position)
+                ),
+                Ordering::Equal
+            );
+            debug_assert_ne!(
+                cmp(
+                    greater_focus.index(greater_position),
+                    equal_focus.index(equal_position)
+                ),
+                Ordering::Equal
+            );
+            mem::swap(
+                less_focus.index_mut(less_position),
+                greater_focus.index_mut(greater_position),
+            );
+            less_position += 1;
+            greater_position += 1;
+        }
     }
 
-    if r1 >= 0 {
-        do_quicksort(vector, left, r1 as usize, cmp, rng);
+    // Now we have partitioned both sides correctly, we just have to recurse now
+    do_quicksort(less_focus, cmp, rng);
+    if !greater_focus.is_empty() {
+        do_quicksort(greater_focus, cmp, rng);
     }
-    do_quicksort(vector, l1 as usize, right, cmp, rng);
 }
 
-pub(crate) fn quicksort<A, F>(vector: &mut FocusMut<'_, A>, left: usize, right: usize, cmp: &F)
+pub(crate) fn quicksort<A, F>(vector: FocusMut<'_, A>, cmp: &F)
 where
     A: Clone,
     F: Fn(&A, &A) -> Ordering,
 {
     let mut rng = rand_xoshiro::Xoshiro256Plus::seed_from_u64(0);
-    do_quicksort(vector, left, right, cmp, &mut rng);
+    do_quicksort(vector, cmp, &mut rng);
 }
 
 #[cfg(test)]
@@ -108,7 +195,7 @@ mod test {
             let mut vec = input.clone();
             let len = vec.len();
             if len > 1 {
-                quicksort(&mut vec.focus_mut(), 0, len - 1, &Ord::cmp);
+                quicksort(vec.focus_mut(), &Ord::cmp);
             }
             assert!(is_sorted(vec));
         }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1475,7 +1475,7 @@ impl<A: Clone> Vector<A> {
     {
         let len = self.len();
         if len > 1 {
-            sort::quicksort(&mut self.focus_mut(), 0, len - 1, &cmp);
+            sort::quicksort(self.focus_mut(), &cmp);
         }
     }
 


### PR DESCRIPTION
This modifies the sort method to be much more efficient in terms of tree traversals. Swapping two items in the same focus is an expensive operation which the old sort method made extensive use of. This new method fixes that by finding the correct size of the partitions first. The downside to this method is that it makes more comparisons on average. I've noticed in my code is approximately 2x faster with this sort method.

Old sort benchmarks
```
test quicksort_reverse_sorted_list_0500 ... bench:     337,174 ns/iter (+/- 42,349)
test quicksort_reverse_sorted_list_1000 ... bench:     908,472 ns/iter (+/- 88,979)
test quicksort_reverse_sorted_list_1500 ... bench:   1,493,024 ns/iter (+/- 158,607)
test quicksort_reverse_sorted_list_2000 ... bench:   2,359,450 ns/iter (+/- 220,542)
test quicksort_reverse_sorted_list_2500 ... bench:   2,848,659 ns/iter (+/- 191,312)
test quicksort_shuffled_list_0500       ... bench:     436,730 ns/iter (+/- 41,080)
test quicksort_shuffled_list_1000       ... bench:   1,188,585 ns/iter (+/- 133,737)
test quicksort_shuffled_list_1500       ... bench:   2,052,514 ns/iter (+/- 138,074)
test quicksort_shuffled_list_2000       ... bench:   2,985,263 ns/iter (+/- 667,889)
test quicksort_shuffled_list_2500       ... bench:   3,829,387 ns/iter (+/- 318,696)
test quicksort_sorted_list_0500         ... bench:     216,016 ns/iter (+/- 22,613)
test quicksort_sorted_list_1000         ... bench:     683,743 ns/iter (+/- 46,257)
test quicksort_sorted_list_1500         ... bench:   1,625,938 ns/iter (+/- 207,219)
test quicksort_sorted_list_2000         ... bench:   1,819,486 ns/iter (+/- 257,906)
test quicksort_sorted_list_2500         ... bench:   2,782,200 ns/iter (+/- 523,779)
```

New sort benchmarks
```
test quicksort_reverse_sorted_list_0500 ... bench:     170,173 ns/iter (+/- 18,268)
test quicksort_reverse_sorted_list_1000 ... bench:     380,455 ns/iter (+/- 50,027)
test quicksort_reverse_sorted_list_1500 ... bench:     621,704 ns/iter (+/- 69,480)
test quicksort_reverse_sorted_list_2000 ... bench:     831,539 ns/iter (+/- 117,876)
test quicksort_reverse_sorted_list_2500 ... bench:   1,035,705 ns/iter (+/- 94,049)
test quicksort_shuffled_list_0500       ... bench:     201,768 ns/iter (+/- 15,222)
test quicksort_shuffled_list_1000       ... bench:     452,327 ns/iter (+/- 35,051)
test quicksort_shuffled_list_1500       ... bench:     720,080 ns/iter (+/- 96,779)
test quicksort_shuffled_list_2000       ... bench:     990,407 ns/iter (+/- 117,726)
test quicksort_shuffled_list_2500       ... bench:   1,274,549 ns/iter (+/- 99,018)
test quicksort_sorted_list_0500         ... bench:     147,221 ns/iter (+/- 19,687)
test quicksort_sorted_list_1000         ... bench:     332,869 ns/iter (+/- 32,720)
test quicksort_sorted_list_1500         ... bench:     537,311 ns/iter (+/- 42,432)
test quicksort_sorted_list_2000         ... bench:     768,849 ns/iter (+/- 80,387)
test quicksort_sorted_list_2500         ... bench:   1,042,676 ns/iter (+/- 102,850)
```
