### PR TITLE
Would you like a shield?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # im-rs
 
+[![Crate Status](https://img.shields.io/crates/v/im.svg)](https://crates.io/crates/im)
+
 Blazing fast immutable collection datatypes for Rust.
 
 Comes in two versions: [`im`](https://crates.io/crates/im) (thread safe) and


### PR DESCRIPTION
This adds a shield to https://img.shields.io/crates/v/im.svg.

It might be slightly confusing as it ignores `im-rc`, although the versions of the two seem in sync.