### PR TITLE
Implement Clone for by-ref iterators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ debug = []
 [dependencies]
 typenum = "1.12"
 bitmaps = "2"
-sized-chunks = "0.6"
+sized-chunks = { version = "0.6", git = "https://github.com/vorner/sized-chunks", branch = "iter-traits" }
 rand_core = "0.5.1"
 rand_xoshiro = "0.4"
 quickcheck = { version = "0.9", optional = true }

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -1792,6 +1792,7 @@ where
 // // Iterators
 
 /// An iterator over the elements of a map.
+#[derive(Clone)]
 pub struct Iter<'a, K, V> {
     it: NodeIter<'a, (K, V)>,
 }

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -834,6 +834,7 @@ where
 // Iterators
 
 /// An iterator over the elements of a set.
+#[derive(Clone)]
 pub struct Iter<'a, A> {
     it: NodeIter<'a, Value<A>>,
 }

--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -912,6 +912,7 @@ impl<A: BTreeValue> Node<A> {
 // Iterator
 
 /// An iterator over an ordered set.
+#[derive(Clone)]
 pub struct Iter<'a, A> {
     fwd_path: Vec<(&'a Node<A>, usize)>,
     back_path: Vec<(&'a Node<A>, usize)>,

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -472,6 +472,7 @@ impl<A: HashValue> CollisionNode<A> {
 
 // Ref iterator
 
+#[derive(Clone)]
 pub(crate) struct Iter<'a, A> {
     count: usize,
     stack: Vec<ChunkIter<'a, Entry<A>, HashWidth>>,

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -1831,6 +1831,7 @@ where
 // Iterators
 
 /// An iterator over the key/value pairs of a map.
+#[derive(Clone)]
 pub struct Iter<'a, K, V> {
     it: RangedIter<'a, (K, V)>,
 }

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -938,6 +938,7 @@ impl<A: Ord + Debug> Debug for OrdSet<A> {
 // Iterators
 
 /// An iterator over the elements of a set.
+#[derive(Clone)]
 pub struct Iter<'a, A> {
     it: NodeIter<'a, Value<A>>,
 }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1948,6 +1948,7 @@ impl<'a, A: Clone> From<&'a Vec<A>> for Vector<A> {
 /// To obtain one, use [`Vector::iter()`][iter].
 ///
 /// [iter]: enum.Vector.html#method.iter
+#[derive(Clone)]
 pub struct Iter<'a, A> {
     focus: Focus<'a, A>,
     front_index: usize,


### PR DESCRIPTION
Closes #134.

Note that this depends on https://github.com/bodil/sized-chunks/pull/12 and needs merging and release of that first, so the git dependency can be removed. This turns out to be a bit of DFS through dependencies 😇.