### PR TITLE
Add Send and Sync bounds for TreeFocus

### DIFF
--- a/src/vector/focus.rs
+++ b/src/vector/focus.rs
@@ -279,10 +279,10 @@ impl<A> Clone for TreeFocus<A> {
 
 #[allow(unsafe_code)]
 #[cfg(threadsafe)]
-unsafe impl<A> Send for TreeFocus<A> {}
+unsafe impl<A: Send> Send for TreeFocus<A> {}
 #[allow(unsafe_code)]
 #[cfg(threadsafe)]
-unsafe impl<A> Sync for TreeFocus<A> {}
+unsafe impl<A: Sync> Sync for TreeFocus<A> {}
 
 #[inline]
 fn contains<A: Ord>(range: &Range<A>, index: &A) -> bool {


### PR DESCRIPTION
This addresses https://github.com/bodil/im-rs/issues/157 by only making the `TreeFocus` objects send and sync when the underlying type is.