### PR TITLE
Use rand_xoshiro 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ typenum = "1.12"
 bitmaps = "2"
 sized-chunks = "0.6"
 rand_core = "0.5.1"
-rand_xoshiro = "0.4"
+rand_xoshiro = "0.6"
 quickcheck = { version = "0.9", optional = true }
 proptest = { version = "0.10", optional = true }
 serde = { version = "1", optional = true }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::vector::FocusMut;
-use rand_core::{RngCore, SeedableRng};
+use rand_xoshiro::rand_core::{RngCore, SeedableRng};
 use std::cmp::Ordering;
 use std::mem;
 


### PR DESCRIPTION
`rand_xoshiro` 0.6.0 was released a year ago, switch to it to make it possible to package `im` in Fedora, which only carries a single version of each crate.