### PR TITLE
Use const generics instead of typenum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+-  All container types are now covariant over the stored type. (#196)
+
 ## [15.1.0] - 2022-04-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ debug = []
 
 [dependencies]
 typenum = "1.12"
-bitmaps = "2"
-sized-chunks = "0.6.4"
+bitmaps = "3"
+sized-chunks = "0.7"
 rand_core = "0.6"
 rand_xoshiro = "0.6"
 quickcheck = { version = "1", optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,17 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use typenum::*;
-
 /// The branching factor of RRB-trees
-pub(crate) type VectorChunkSize = U64;
+pub(crate) const VECTOR_CHUNK_SIZE: usize = 64;
 
 /// The branching factor of B-trees
-pub(crate) type OrdChunkSize = U64; // Must be an even number!
+pub(crate) const ORD_CHUNK_SIZE: usize = 64; // Must be an even number!
 
 /// The level size of HAMTs, in bits
 /// Branching factor is 2 ^ HashLevelSize.
-pub(crate) type HashLevelSize = U5;
+pub(crate) const HASH_LEVEL_SIZE: usize = 5;
 
 /// The size of per-instance memory pools if the `pool` feature is enabled.
 /// This is set to 0, meaning you have to opt in to using a pool by constructing

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -2125,6 +2125,9 @@ mod test {
     use ::proptest::{collection, proptest};
     use std::hash::BuildHasherDefault;
 
+    assert_covariant!(HashMap<T, i32> in T);
+    assert_covariant!(HashMap<i32, T> in T);
+
     #[test]
     fn safe_mutation() {
         let v1: HashMap<usize, usize> = (0..131_072).map(|i| (i, i)).collect::<HashMap<_, _>>();

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -1070,6 +1070,8 @@ mod test {
     use ::proptest::proptest;
     use std::hash::BuildHasherDefault;
 
+    assert_covariant!(HashSet<T> in T);
+
     #[test]
     fn insert_failing() {
         let mut set: HashSet<i16, BuildHasherDefault<LolHasher>> = Default::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,13 +344,13 @@
 #[macro_use]
 extern crate pretty_assertions;
 
+#[macro_use]
+mod util;
+
 mod config;
 mod nodes;
 mod sort;
 mod sync;
-
-#[macro_use]
-mod util;
 
 #[macro_use]
 mod ord;

--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -8,16 +8,15 @@ use std::mem;
 use std::ops::{Bound, RangeBounds};
 
 use sized_chunks::Chunk;
-use typenum::{Add1, Unsigned};
 
-use crate::config::OrdChunkSize as NodeSize;
+pub(crate) use crate::config::ORD_CHUNK_SIZE as NODE_SIZE;
 use crate::util::{Pool, PoolClone, PoolDefault, PoolRef};
 
 use self::Insert::*;
 use self::InsertAction::*;
 
-pub(crate) const NODE_SIZE: usize = NodeSize::USIZE;
 const MEDIAN: usize = (NODE_SIZE + 1) >> 1;
+const NUM_CHILDREN: usize = NODE_SIZE + 1;
 
 pub trait BTreeValue {
     type Key;
@@ -38,8 +37,8 @@ pub trait BTreeValue {
 }
 
 pub(crate) struct Node<A> {
-    keys: Chunk<A, NodeSize>,
-    children: Chunk<Option<PoolRef<Node<A>>>, Add1<NodeSize>>,
+    keys: Chunk<A, NODE_SIZE>,
+    children: Chunk<Option<PoolRef<Node<A>>>, NUM_CHILDREN>,
 }
 
 #[cfg(feature = "pool")]

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -7,10 +7,6 @@ pub(crate) mod hamt;
 pub(crate) mod rrb;
 
 pub(crate) mod chunk {
-    use crate::config::VectorChunkSize;
-    use sized_chunks as sc;
-    use typenum::Unsigned;
-
-    pub(crate) type Chunk<A> = sc::sized_chunk::Chunk<A, VectorChunkSize>;
-    pub(crate) const CHUNK_SIZE: usize = VectorChunkSize::USIZE;
+    pub(crate) use crate::config::VECTOR_CHUNK_SIZE as CHUNK_SIZE;
+    pub(crate) type Chunk<A> = sized_chunks::sized_chunk::Chunk<A, CHUNK_SIZE>;
 }

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -2190,6 +2190,9 @@ mod test {
     use ::proptest::num::{i16, usize};
     use ::proptest::{bool, collection, proptest};
 
+    assert_covariant!(OrdMap<T, i32> in T);
+    assert_covariant!(OrdMap<i32, T> in T);
+
     #[test]
     fn iterates_in_order() {
         let map = ordmap! {

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -1185,6 +1185,8 @@ mod test {
     use crate::proptest::*;
     use ::proptest::proptest;
 
+    assert_covariant!(OrdSet<T> in T);
+
     #[test]
     fn match_strings_with_string_slices() {
         let mut set: OrdSet<String> = From::from(&ordset!["foo", "bar"]);

--- a/src/util.rs
+++ b/src/util.rs
@@ -140,3 +140,16 @@ macro_rules! def_pool {
         }
     };
 }
+
+#[cfg(test)]
+macro_rules! assert_covariant {
+    ($name:ident<$($gen:tt),*> in $param:ident) => {
+        #[allow(unused_assignments, unused_variables)]
+        const _: () = {
+            type Tmp<$param> = $name<$($gen),*>;
+            fn assign<'a, 'b: 'a>(src: Tmp<&'b i32>, mut dst: Tmp<&'a i32>) {
+                dst = src;
+            }
+        };
+    }
+}

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -2270,6 +2270,8 @@ mod test {
     use ::proptest::num::{i32, usize};
     use ::proptest::proptest;
 
+    assert_covariant!(Vector<T> in T);
+
     #[test]
     fn macro_allows_trailing_comma() {
         let vec1 = vector![1, 2, 3];


### PR DESCRIPTION
This has the (desired) side effect of making containers covariant over
their input type, so we also add some assertions to ensure that this
doesn't regress.

Fixes #196.