### PR TITLE
Expose values_mut, similar to std::collections::HashMap::values_mut

### DIFF
--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -337,6 +337,19 @@ impl<K, V, S> HashMap<K, V, S> {
         }
     }
 
+    /// Get a mutable iterator over a hash map's values.
+    ///
+    /// Please note that the order is consistent between maps using
+    /// the same hasher, but no other ordering guarantee is offered.
+    /// Items will not come out in insertion order or sort order.
+    /// They will, however, come out in the same order every time for
+    /// the same map.
+    #[inline]
+    #[must_use]
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
+        self.iter_mut().map(|(_, v)| v)
+    }
+
     /// Discard all elements from the map.
     ///
     /// This leaves you with an empty map, and all elements that


### PR DESCRIPTION
Hey! I noticed `im` seems to not have the `values_mut()` helper function for hashmaps, so I'm sending this PR implementing it.

WDYT?

(Disclaimer: I wrote this in the github web editor, as it's making use of impl Trait for apparently the first time in this file I wanted to check this approach would be OK with you before sinking too much time in it)