### PR TITLE
Fix relative_complement doctests to use the correct data structures

### DIFF
--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -1245,10 +1245,10 @@ where
     ///
     /// ```
     /// # #[macro_use] extern crate im;
-    /// # use im::ordmap::OrdMap;
-    /// let map1 = ordmap!{1 => 1, 3 => 4};
-    /// let map2 = ordmap!{2 => 2, 3 => 5};
-    /// let expected = ordmap!{1 => 1};
+    /// # use im::hashmap::HashMap;
+    /// let map1 = hashmap!{1 => 1, 3 => 4};
+    /// let map2 = hashmap!{2 => 2, 3 => 5};
+    /// let expected = hashmap!{1 => 1};
     /// assert_eq!(expected, map1.relative_complement(map2));
     /// ```
     #[inline]

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -593,10 +593,10 @@ where
     ///
     /// ```
     /// # #[macro_use] extern crate im;
-    /// # use im::ordset::OrdSet;
-    /// let set1 = ordset!{1, 2};
-    /// let set2 = ordset!{2, 3};
-    /// let expected = ordset!{1};
+    /// # use im::hashset::HashSet;
+    /// let set1 = hashset!{1, 2};
+    /// let set2 = hashset!{2, 3};
+    /// let expected = hashset!{1};
     /// assert_eq!(expected, set1.relative_complement(set2));
     /// ```
     #[must_use]


### PR DESCRIPTION
Previously, the doctests for the relative_complement method of both HashSet and HashMap used the corresponding Ord* data structures.