### PR TITLE
Fix a bug in BTree get_next and get_prev search

### DIFF
--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -248,7 +248,11 @@ impl<A: BTreeValue> Node<A> {
             Err(index) => match self.children[index] {
                 None if index == 0 => None,
                 None => self.keys.get(index - 1).map(|_| &self.keys[index - 1]),
-                Some(ref node) => node.lookup_prev(key),
+                Some(ref node) => match node.lookup_prev(key) {
+                    None if index == 0 => None,
+                    None => self.keys.get(index - 1).map(|_| &self.keys[index - 1]),
+                    Some(key) => Some(key),
+                },
             },
         }
     }
@@ -265,7 +269,10 @@ impl<A: BTreeValue> Node<A> {
             Ok(index) => Some(&self.keys[index]),
             Err(index) => match self.children[index] {
                 None => self.keys.get(index).map(|_| &self.keys[index]),
-                Some(ref node) => node.lookup_next(key),
+                Some(ref node) => match node.lookup_next(key) {
+                    None => self.keys.get(index).map(|_| &self.keys[index]),
+                    Some(key) => Some(key),
+                },
             },
         }
     }

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -2645,5 +2645,19 @@ mod test {
             }).collect();
             assert_eq!(expected, diff);
         }
+
+        #[test]
+        fn get_next_and_prev(count in 0..1000) {
+            let values = (0..count).map(|i| ((i + 1) * 2, ())).collect::<Vec<_>>();
+
+            let set = values.iter().cloned().collect::<OrdMap<i32, ()>>();
+            for value in &values {
+                let next = value.0 + 1;
+                assert_eq!(set.get_prev(&next), Some((&value.0, &value.1)));
+
+                let prev = value.0 - 1;
+                assert_eq!(set.get_next(&prev), Some((&value.0, &value.1)));
+            }
+        }
     }
 }

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -1239,5 +1239,19 @@ mod test {
             let result: Vec<i32> = set.range(..).rev().cloned().collect();
             assert_eq!(expected, result);
         }
+
+        #[test]
+        fn get_next_and_prev(count in 0..1000) {
+            let values = (0..count).map(|i| (i + 1) * 2).collect::<Vec<_>>();
+
+            let set = values.iter().cloned().collect::<OrdSet<i32>>();
+            for value in &values {
+                let next = *value + 1;
+                assert_eq!(set.get_prev(&next), Some(value));
+
+                let prev = *value - 1;
+                assert_eq!(set.get_next(&prev), Some(value));
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #215 

Previously, we weren't accounting for separator keys correctly in the recursive search. This commit fixes that and adds property tests.

For example, if the root node had a separator with key `66` and the right child node had keys `[68, 69, 70, ...]`, a call to `lookup_prev(67)` would recurse into the child, find that there is nothing less than or equal to 67, and then bubble up a `None` value all the way. The correct behavior is to return `66` from the parent node.

The changeset here amends the search to return the previous separator when searching a child returns `None`.